### PR TITLE
[#1] You no longer double back in snake game.

### DIFF
--- a/ArcadeRecreations/Assets/Scripts/FQ.GameplayElements.EditorTests/Player/Snake/SnakeBehaviourPositionTests.cs
+++ b/ArcadeRecreations/Assets/Scripts/FQ.GameplayElements.EditorTests/Player/Snake/SnakeBehaviourPositionTests.cs
@@ -324,6 +324,34 @@ namespace FQ.GameplayElements.EditorTests
                 $"Expected {expectedPosition.ToString()} Actual {actualPosition.ToString()}");
         }
         
+        [Test]
+        [Description("This test ensures that pressing counter directions does not lead to backwards motion.")]
+        public void Update_PlayerDoesNotDoubleBack_WhenMovingLeftAndPressingUpAndRightTest()
+        {
+            // Arrange
+            Vector2 expectedPosition = CopyVector3(this.playerObject.transform.position);
+            expectedPosition.x--;
+            expectedPosition.y++;
+
+            this.mockGameplayInputs.Setup(
+                x => x.KeyPressed(GameplayButton.DirectionLeft)).Returns(true);
+            RunMovementUpdateCycle();
+            this.mockGameplayInputs.Setup(
+                x => x.KeyPressed(GameplayButton.DirectionLeft)).Returns(false);
+            this.mockGameplayInputs.Setup(
+                x => x.KeyPressed(GameplayButton.DirectionRight)).Returns(true);
+            this.mockGameplayInputs.Setup(
+                x => x.KeyPressed(GameplayButton.DirectionUp)).Returns(true);
+
+            // Act
+            RunMovementUpdateCycle();
+
+            // Assert
+            Vector2 actualPosition = this.playerObject.transform.position;
+            Assert.AreEqual(expectedPosition, actualPosition, 
+                $"Expected {expectedPosition.ToString()} Actual {actualPosition.ToString()}");
+        }
+
         #endregion
         
         #region Position with KeyDown


### PR DESCRIPTION
This was implemented with two variables, a current and next direction. Re-using the current direction meant that the opposite direction kept being evaluated on the current direction before movement had taken place. This lead to an effect where the update loop did not double back but because the movement loop is slower, it actually did.